### PR TITLE
Add protocol string to Opensearch endpoint if missing

### DIFF
--- a/src/main/java/com/amazonaws/datastreamvectorization/utils/ValidationUtils.java
+++ b/src/main/java/com/amazonaws/datastreamvectorization/utils/ValidationUtils.java
@@ -29,6 +29,7 @@ public class ValidationUtils {
 
     public static final Pattern VALID_URL_PATTERN =
             Pattern.compile("[-a-zA-Z0-9/@%._~&+$]+\\.[a-zA-Z]{2,6}\\b[-a-zA-Z0-9~/=+:?#_%&$(),]*");
+    private static final Pattern VALID_PROTOCOL_PATTERN = Pattern.compile("^((http|https)://).*");
     private static final Pattern VALID_HTTP_URL_PATTERN =
             Pattern.compile("((http|https)://)" + VALID_URL_PATTERN);
     public static final Pattern VALID_IP_PATTERN =
@@ -45,6 +46,17 @@ public class ValidationUtils {
             return false;
         }
         final Matcher matcher = VALID_HTTP_URL_PATTERN.matcher(url);
+        return matcher.matches();
+    }
+
+    /**
+     * Checks if a URL starts with a valid protocol
+     *
+     * @param url
+     * @return True if the URL starts with a valid protocol
+     */
+    public static boolean hasValidProtocol(final String url) {
+        final Matcher matcher = VALID_PROTOCOL_PATTERN.matcher(url);
         return matcher.matches();
     }
 }

--- a/src/test/java/com/amazonaws/datastreamvectorization/utils/ValidationUtilsTest.java
+++ b/src/test/java/com/amazonaws/datastreamvectorization/utils/ValidationUtilsTest.java
@@ -26,7 +26,7 @@ class ValidationUtilsTest {
 
     @ParameterizedTest
     @ValueSource(strings = {StringUtils.EMPTY, "  ", "urn:some:uri:1.2.3", "telnet://aws.jam", "https:amazon.com", "https::amazon.com",
-            "ftp://amazon.com"})
+            "ftp://amazon.com", "https://", "http://", "http://abc"})
     void isValidUrl_ShouldReturnFalse(String input) {
         assertFalse(ValidationUtils.isValidUrl(input));
     }
@@ -37,5 +37,23 @@ class ValidationUtilsTest {
             "https://dashboards.us-east-1.aoss.amazonaws.com/_login/?collectionId=ad77zixjklwz3asd0dti"})
     void isValidUrl_ShouldReturnTrue(String input) {
         assertTrue(ValidationUtils.isValidUrl(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"htt://ad77zixjklwz3asd0dti.us-east-1.aoss.amazonaws.com",
+            "http:/vpc-test-7a27u4iagoq5cthd2m6upmenlu.us-east-1.es.amazonaws.com",
+            "abc", "https//vpc-test-7a27u4iagoq5cthd2m6upmenlu.us-east-1.es.amazonaws.com",
+            "ahttps://ad77zixjklwz3asd0dti.us-east-1.aoss.amazonaws.com", ""})
+    void hasValidProtocol_ShouldReturnFalse(String input) {
+        assertFalse(ValidationUtils.hasValidProtocol(input));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"https://ad77zixjklwz3asd0dti.us-east-1.aoss.amazonaws.com",
+            "http://vpc-test-7a27u4iagoq5cthd2m6upmenlu.us-east-1.es.amazonaws.com",
+            "https:///ad77zixjklwz3asd0dti.us-east-1.aoss.amazonaws.com",
+            "https://", "http://", "http://abc"})
+    void hasValidProtocol_ShouldReturnTrue(String input) {
+        assertTrue(ValidationUtils.hasValidProtocol(input));
     }
 }


### PR DESCRIPTION
*Description of changes:*

- Add protocol `https://` to the beginning of the OpenSearch endpoint URL if there is no protocol string (`http://` or `https://`) at the start of the URL.
- Updated the VPCE creation lambda in CDK to not attempt to create any OpenSearch VPCEs if the provisioned OpenSearch domain is public and not in a VPC. The response for the lambda when this happens shows in the stack output text, which says that OS VPCE ID not applicable for public OS domains. 
