### PR TITLE
Lower default chunking max segment sizes

### DIFF
--- a/src/main/java/com/amazonaws/datastreamvectorization/embedding/model/EmbeddingModel.java
+++ b/src/main/java/com/amazonaws/datastreamvectorization/embedding/model/EmbeddingModel.java
@@ -39,16 +39,16 @@ import static com.amazonaws.datastreamvectorization.constants.CommonConstants.Em
 public enum EmbeddingModel {
 
     AMAZON_TITAN_TEXT_G1("amazon.titan-embed-text-v1", "inputText", String.class, "embedding",
-            Collections.emptyMap(), Collections.emptyMap(), 50000),
+            Collections.emptyMap(), Collections.emptyMap(), 50000, 16000),
     AMAZON_TITAN_TEXT_V2("amazon.titan-embed-text-v2:0", "inputText", String.class, "embedding",
             Collections.emptyMap(),
             Map.of(NORMALIZE, Boolean.class,
                     DIMENSIONS, Integer.class
-    ), 50000),
+    ), 50000, 16000),
     AMAZON_TITAN_MULTIMODAL_G1("amazon.titan-embed-image-v1", "inputText", String.class, "embedding",
             Collections.emptyMap(), Map.of(
             OUTPUT_EMBEDDING_LENGTH, Integer.class
-    ), 100000),
+    ), 100000, 50000),
     /*
     For Cohere models, we add a default input_type since this is a required field. In search use-cases,
     search_document is used when you encode documents for embeddings that you store in a vector database.
@@ -59,13 +59,13 @@ public enum EmbeddingModel {
             INPUT_TYPE, String.class,
             TRUNCATE, String.class,
             EMBEDDING_TYPES, String.class
-    ), 2048),
+    ), 2048, 1000),
     COHERE_EMBED_MULTILINGUAL("cohere.embed-multilingual-v3", "texts", JSONArray.class, "embeddings",
             Map.of(INPUT_TYPE, INPUT_TYPE_SEARCH_DOCUMENT), Map.of(
             INPUT_TYPE, String.class,
             TRUNCATE, String.class,
             EMBEDDING_TYPES, String.class
-    ), 2048);
+    ), 2048, 1000);
 
     /**
      * Bedrock model ID.
@@ -98,4 +98,9 @@ public enum EmbeddingModel {
      * Bedrock model max character limit of the text to embed in a request.
      */
     private final int modelMaxCharacterLimit;
+
+    /**
+     * Bedrock model default character limit of the text to embed in a request.
+     */
+    private final int modelDefaultCharacterLimit;
 }

--- a/src/main/java/com/amazonaws/datastreamvectorization/utils/PropertiesUtils.java
+++ b/src/main/java/com/amazonaws/datastreamvectorization/utils/PropertiesUtils.java
@@ -206,10 +206,11 @@ public class PropertiesUtils {
             }
             return chunkingMaxSegmentSize;
         }
-        log.info("Did not find {} in config. Setting it to default value {}",
+        log.info("Did not find {} in config. Setting it to default value {} for the model {}",
                 PROPERTY_EMBEDDING_INPUT_CHUNKING_MAX_SIZE,
-                embeddingConfig.getEmbeddingModel().getModelMaxCharacterLimit());
-        return embeddingConfig.getEmbeddingModel().getModelMaxCharacterLimit();
+                embeddingConfig.getEmbeddingModel().getModelDefaultCharacterLimit(),
+                embeddingConfig.getEmbeddingModel().getModelId());
+        return embeddingConfig.getEmbeddingModel().getModelDefaultCharacterLimit();
     }
 
     public static int getChunkingMaxOverlapSize(EmbeddingConfiguration embeddingConfig) {
@@ -270,6 +271,6 @@ public class PropertiesUtils {
         if (OVERRIDE_VALUES_TO_VALIDATIONS_MAP.containsKey(configName)) {
             return OVERRIDE_VALUES_TO_VALIDATIONS_MAP.get(configName).stream().anyMatch(v -> v.equals(configValue));
         }
-         return true;
+        return true;
     }
 }


### PR DESCRIPTION
For each embedding model, lowered the default chunking max segment size in characters from the max character limit to a lower value for each Bedrock embedding model so that model token count limits are not hit with the default configuration.

- Amazon Titan Text Embeddings V1
    - Token limit: 8,192 tokens
    - Max character limit: 50,000
    - New default character limit: 16,000
- Amazon Titan Text Embeddings V2
    - Token limit: 8,192 tokens
    - Max character limit: 50,000
    - New default character limit: 16,000
- Amazon Titan Multimodal Embeddings G1
    - Token limit: 128 tokens
    - Max character limit: 100,000
    - New default character limit: 50,000
- Cohere Embed English
    - Token limit: 512 tokens
    - Max character limit: 2048
    - New default character limit: 1000
- Cohere Embed Multilingual
    - Token limit: 512 tokens
    - Max character limit: 2048
    - New default character limit: 1000


